### PR TITLE
fix error: Could not find the requested service ondemand: host

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     name: ondemand
     state: stopped
     enabled: no
+  ignore_errors: yes
 
 - name: bounce service if necessary
   service:


### PR DESCRIPTION
Ignore error when `ondemand.service` is not installed on system.

FAILED! => {"ansible_facts": {"discovered_interpreter_python":
"/usr/bin/python3"}, "changed": false, "msg": "Could not find the
requested service ondemand: host"}