### PR TITLE
Don't include {{ }} in conditional test

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,4 +37,4 @@
     state: restarted
   when:
     - sysfs_file.stat.exists
-    - "'{{ current_governor.stdout }}' != '{{ cpufreq_governor }}'"
+    - current_governor.stdout != cpufreq_governor


### PR DESCRIPTION
The current syntax is throwing a warning
There is no need to include {{ and }} for conditional tests

![image](https://github.com/ldx/ansible-cpufrequtils/assets/80455946/dcd5bdee-97fa-4a23-80e5-077c73ef5cea)
